### PR TITLE
return error tuple when rpc.call fails

### DIFF
--- a/lib/nebulex/adapters/dist.ex
+++ b/lib/nebulex/adapters/dist.ex
@@ -263,6 +263,8 @@ defmodule Nebulex.Adapters.Dist do
     case :rpc.call(node, mod, fun, args) do
       {:badrpc, {:EXIT, {remote_ex, _}}} ->
         raise remote_ex
+      {:badrpc, _} = err ->
+        {:error, err}
       response ->
         response
     end


### PR DESCRIPTION
Makes it easier to handle errors.

An alternative would be to document somewhere that the distributed cache can return `{:badrpc, reason}` tuples.