### PR TITLE
Copy the TTL from the previous generation

### DIFF
--- a/lib/nebulex/adapters/local.ex
+++ b/lib/nebulex/adapters/local.ex
@@ -445,9 +445,12 @@ defmodule Nebulex.Adapters.Local do
     unix_time() + diff
   end
 
-  defp diff_epoch(other) do
+  defp diff_epoch(other) when is_number(other) do
     other - unix_time()
   end
+
+  defp diff_epoch(_),
+    do: :infinity
 
   defp unix_time() do
     {mega, secs, _} = :os.timestamp()

--- a/lib/nebulex/adapters/local.ex
+++ b/lib/nebulex/adapters/local.ex
@@ -439,11 +439,11 @@ defmodule Nebulex.Adapters.Local do
     end
   end
 
-  defp seconds_since_epoch(nil),
-    do: :infinity
-  defp seconds_since_epoch(diff) when is_integer(diff) do
+  defp seconds_since_epoch(diff) when is_number(diff) do
     unix_time() + diff
   end
+  defp seconds_since_epoch(_),
+    do: :infinity
 
   defp diff_epoch(other) when is_number(other) do
     other - unix_time()


### PR DESCRIPTION
The way it currently works, whenever there's a cache-hit in a previous generation that is copied to the hot cache, the TTL for the item will either be set to `:infinity` or replaced with whatever's currently in `opts`.

This falls back to re-using the TTL unless an override is provided.