### PR TITLE
Fix error when running in a release

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,9 +33,7 @@ defmodule Nebulex.Mixfile do
   end
 
   def application do
-    [
-      applications: []
-    ]
+    []
   end
 
   defp deps do


### PR DESCRIPTION
When attempting to run a release build of an app that uses Nebulex, trying to start a cache will result in an error that looks something like the following:

```
[info] Application my_app exited: MyApp.Application.start(:normal, []) returned an error: shutdown: failed to start child: MyApp.Cache
    ** (EXIT) shutdown: failed to start child: MyApp.Cache.ShardsSupervisor
        ** (EXIT) an exception was raised:
            ** (UndefinedFunctionError) function :shards_sup.start_link/1 is undefined (module :shards_sup is not available)
                :shards_sup.start_link(MyApp.Cache.ShardsSupervisor)
                (stdlib) supervisor.erl:379: :supervisor.do_start_child_i/3 
                (stdlib) supervisor.erl:365: :supervisor.do_start_child/2
                (stdlib) supervisor.erl:349: anonymous fn/3 in :supervisor.start_children/2
                (stdlib) supervisor.erl:1157: :supervisor.children_map/4
                (stdlib) supervisor.erl:315: :supervisor.init_children/2
                (stdlib) gen_server.erl:374: :gen_server.init_it/2
                (stdlib) gen_server.erl:342: :gen_server.init_it/6
                (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

This happens because the `:shards` dependency is not packaged as part of the release. Removing the explicit `:applications` list and instead letting Elixir automatically infer the applications list (a feature [introduced in Elixir v1.4](https://elixir-lang.org/blog/2017/01/05/elixir-v1-4-0-released/#application-inference)) fixes the issue.

(BTW, I left the `application/0` function around (even though it now returns an empty list), but I'm pretty sure you could also just remove its declaration entirely)