### PR TITLE
Avoid calling `cacheable()` method when cached value is `false`

### DIFF
--- a/lib/nebulex/caching.ex
+++ b/lib/nebulex/caching.ex
@@ -478,10 +478,9 @@ if Code.ensure_loaded?(Decorator.Define) do
       quote do
         key = unquote(keygen)
 
-        if value = cache.get(key, opts) do
-          value
-        else
-          Caching.eval_match(unquote(block), match, cache, key, opts)
+        case cache.get(key, opts) do
+          nil -> Caching.eval_match(unquote(block), match, cache, key, opts)
+          value -> value
         end
       end
     end

--- a/test/nebulex/caching_test.exs
+++ b/test/nebulex/caching_test.exs
@@ -127,6 +127,14 @@ defmodule Nebulex.CachingTest do
       assert get_without_args() == "hello"
       assert Cache.get(0) == "hello"
     end
+
+    test "with side effects and returning false (issue #)" do
+      refute Cache.get("side-effect")
+      assert get_false_with_side_effect(false) == false
+      assert Cache.get("side-effect") == 1
+      assert get_false_with_side_effect(false) == false
+      assert Cache.get("side-effect") == 1
+    end
   end
 
   describe "cache_put" do
@@ -260,6 +268,12 @@ defmodule Nebulex.CachingTest do
   @decorate cacheable(cache: Cache, opts: [ttl: 1000])
   def get_with_opts(x) do
     x
+  end
+
+  @decorate cacheable(cache: Cache)
+  def get_false_with_side_effect(v) do
+    Cache.update("side-effect", 1, &(&1 + 1))
+    v
   end
 
   @decorate cacheable(cache: Cache, match: fn x -> x != :x end)

--- a/test/nebulex/caching_test.exs
+++ b/test/nebulex/caching_test.exs
@@ -128,7 +128,7 @@ defmodule Nebulex.CachingTest do
       assert Cache.get(0) == "hello"
     end
 
-    test "with side effects and returning false (issue #)" do
+    test "with side effects and returning false (issue #111)" do
       refute Cache.get("side-effect")
       assert get_false_with_side_effect(false) == false
       assert Cache.get("side-effect") == 1


### PR DESCRIPTION
ref issue #111 

I tested the side effect using another cache key on the same cache, any feedback is more than welcome =)