### PR TITLE
Fix max_size to be actually 1 million instead of 100,000

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -83,7 +83,7 @@ config :blog, Blog.Cache,
   # GC interval for pushing new generation: 12 hrs
   gc_interval: :timer.hours(12),
   # Max 1 million entries in cache
-  max_size: 1_00_000,
+  max_size: 1_000_000,
   # Max 2 GB of memory
   allocated_memory: 2_000_000_000,
   # GC min timeout: 10 sec
@@ -102,7 +102,7 @@ config :blog, Blog.Cache,
   # GC interval for pushing new generation: 12 hrs
   gc_interval: :timer.hours(12),
   # Max 1 million entries in cache
-  max_size: 1_00_000,
+  max_size: 1_000_000,
   # Max 2 GB of memory
   allocated_memory: 2_000_000_000,
   # GC min timeout: 10 sec
@@ -526,7 +526,7 @@ config :blog, Blog.PartitionedCache,
     # GC interval for pushing new generation: 12 hrs
     gc_interval: :timer.hours(12),
     # Max 1 million entries in cache
-    max_size: 1_00_000,
+    max_size: 1_000_000,
     # Max 2 GB of memory
     allocated_memory: 2_000_000_000,
     # GC min timeout: 10 sec
@@ -625,7 +625,7 @@ config :blog, Blog.NearCache,
       # GC interval for pushing new generation: 12 hrs
       gc_interval: :timer.hours(12),
       # Max 1 million entries in cache
-      max_size: 1_00_000
+      max_size: 1_000_000
     },
     # Default auto-generated L2 cache (partitioned cache)
     {
@@ -634,7 +634,7 @@ config :blog, Blog.NearCache,
         # GC interval for pushing new generation: 12 hrs
         gc_interval: :timer.hours(12),
         # Max 1 million entries in cache
-        max_size: 1_00_000
+        max_size: 1_000_000
       ]
     }
   ]

--- a/lib/mix/tasks/nbx.gen.cache.ex
+++ b/lib/mix/tasks/nbx.gen.cache.ex
@@ -184,7 +184,7 @@ defmodule Mix.Tasks.Nbx.Gen.Cache do
     # GC interval for pushing new generation: 12 hrs
     gc_interval: :timer.hours(12),
     # Max 1 million entries in cache
-    max_size: 1_00_000,
+    max_size: 1_000_000,
     # Max 2 GB of memory
     allocated_memory: 2_000_000_000,
     # GC min timeout: 10 sec
@@ -201,7 +201,7 @@ defmodule Mix.Tasks.Nbx.Gen.Cache do
       # GC interval for pushing new generation: 12 hrs
       gc_interval: :timer.hours(12),
       # Max 1 million entries in cache
-      max_size: 1_00_000,
+      max_size: 1_000_000,
       # Max 2 GB of memory
       allocated_memory: 2_000_000_000,
       # GC min timeout: 10 sec
@@ -221,7 +221,7 @@ defmodule Mix.Tasks.Nbx.Gen.Cache do
         # GC interval for pushing new generation: 12 hrs
         gc_interval: :timer.hours(12),
         # Max 1 million entries in cache
-        max_size: 1_00_000
+        max_size: 1_000_000
       },
       # Default auto-generated L2 cache (partitioned cache)
       {
@@ -230,7 +230,7 @@ defmodule Mix.Tasks.Nbx.Gen.Cache do
           # GC interval for pushing new generation: 12 hrs
           gc_interval: :timer.hours(12),
           # Max 1 million entries in cache
-          max_size: 1_00_000
+          max_size: 1_000_000
         ]
       }
     ]

--- a/test/mix/tasks/nbx.gen.cache_test.exs
+++ b/test/mix/tasks/nbx.gen.cache_test.exs
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Nbx.Gen.CacheTest do
           # GC interval for pushing new generation: 12 hrs
           gc_interval: :timer.hours(12),
           # Max 1 million entries in cache
-          max_size: 1_00_000,
+          max_size: 1_000_000,
           # Max 2 GB of memory
           allocated_memory: 2_000_000_000,
           # GC min timeout: 10 sec
@@ -120,7 +120,7 @@ defmodule Mix.Tasks.Nbx.Gen.CacheTest do
             # GC interval for pushing new generation: 12 hrs
             gc_interval: :timer.hours(12),
             # Max 1 million entries in cache
-            max_size: 1_00_000,
+            max_size: 1_000_000,
             # Max 2 GB of memory
             allocated_memory: 2_000_000_000,
             # GC min timeout: 10 sec
@@ -157,7 +157,7 @@ defmodule Mix.Tasks.Nbx.Gen.CacheTest do
             # GC interval for pushing new generation: 12 hrs
             gc_interval: :timer.hours(12),
             # Max 1 million entries in cache
-            max_size: 1_00_000,
+            max_size: 1_000_000,
             # Max 2 GB of memory
             allocated_memory: 2_000_000_000,
             # GC min timeout: 10 sec
@@ -213,7 +213,7 @@ defmodule Mix.Tasks.Nbx.Gen.CacheTest do
               # GC interval for pushing new generation: 12 hrs
               gc_interval: :timer.hours(12),
               # Max 1 million entries in cache
-              max_size: 1_00_000
+              max_size: 1_000_000
             },
             # Default auto-generated L2 cache (partitioned cache)
             {
@@ -222,7 +222,7 @@ defmodule Mix.Tasks.Nbx.Gen.CacheTest do
                 # GC interval for pushing new generation: 12 hrs
                 gc_interval: :timer.hours(12),
                 # Max 1 million entries in cache
-                max_size: 1_00_000
+                max_size: 1_000_000
               ]
             }
           ]


### PR DESCRIPTION
**Issue**
Fix a typo for cache max_size: the comment says it is 1 million, but the number specifies 100,000 (`1_00_000`).
This also generates incorrect config file when using `mix nbx.gen.cache -c`


I assume it's a just typo. But let me know if I should change anything.