### PR TITLE
Ensures `Decorator` is compiled first

### DIFF
--- a/lib/nebulex/caching.ex
+++ b/lib/nebulex/caching.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Decorator.Define) do
+if Code.ensure_compiled(Decorator.Define) do
   defmodule Nebulex.Caching do
     @moduledoc """
     Declarative annotation-based caching via function

--- a/lib/nebulex/hook.ex
+++ b/lib/nebulex/hook.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Decorator.Define) do
+if Code.ensure_compiled(Decorator.Define) do
   defmodule Nebulex.Hook do
     @moduledoc """
     Pre/Post Hooks


### PR DESCRIPTION
Given we cannot control the compilation order of dependencies, we ran into an issue where attempting to `use Nebulex.Caching` results in the following error:

`module Nebulex.Caching is not loaded and could not be found.`

This is due to Nebulex being compiled before Decorator.

Switching to using `Code.ensure_compiled` fixes this.