### PR TITLE
New adapter with Horde

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Horde | Nebulex.Adapters.Horde | [nebulex_adapters_horde][nbx_horde]
 [nil]: http://hexdocs.pm/nebulex/Nebulex.Adapters.Nil.html
 [nbx_cachex]: https://github.com/cabol/nebulex_adapters_cachex
 [nbx_redis]: https://github.com/cabol/nebulex_redis_adapter
-[nbx_horde]: https://github.com/cabol/nebulex_adapters_horde
+[nbx_horde]: https://github.com/eliasdarruda/nebulex_adapters_horde
 
 
 For example, if you want to use a built-in cache, add to your `mix.exs` file:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Multilevel | [Nebulex.Adapters.Multilevel][ma] | Built-In
 Nil (special adapter that disables the cache) | [Nebulex.Adapters.Nil][nil] | Built-In
 Cachex | Nebulex.Adapters.Cachex | [nebulex_adapters_cachex][nbx_cachex]
 Redis | NebulexRedisAdapter | [nebulex_redis_adapter][nbx_redis]
+Horde | Nebulex.Adapters.Horde | [nebulex_adapters_horde][nbx_horde]
 
 [la]: http://hexdocs.pm/nebulex/Nebulex.Adapters.Local.html
 [pa]: http://hexdocs.pm/nebulex/Nebulex.Adapters.Partitioned.html
@@ -57,6 +58,8 @@ Redis | NebulexRedisAdapter | [nebulex_redis_adapter][nbx_redis]
 [nil]: http://hexdocs.pm/nebulex/Nebulex.Adapters.Nil.html
 [nbx_cachex]: https://github.com/cabol/nebulex_adapters_cachex
 [nbx_redis]: https://github.com/cabol/nebulex_redis_adapter
+[nbx_horde]: https://github.com/cabol/nebulex_redis_adapter
+
 
 For example, if you want to use a built-in cache, add to your `mix.exs` file:
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Multilevel | [Nebulex.Adapters.Multilevel][ma] | Built-In
 Nil (special adapter that disables the cache) | [Nebulex.Adapters.Nil][nil] | Built-In
 Cachex | Nebulex.Adapters.Cachex | [nebulex_adapters_cachex][nbx_cachex]
 Redis | NebulexRedisAdapter | [nebulex_redis_adapter][nbx_redis]
-Horde | Nebulex.Adapters.Horde | [nebulex_adapters_horde][nbx_horde]
+Distributed with Horde | Nebulex.Adapters.Horde | [nebulex_adapters_horde][nbx_horde]
 
 [la]: http://hexdocs.pm/nebulex/Nebulex.Adapters.Local.html
 [pa]: http://hexdocs.pm/nebulex/Nebulex.Adapters.Partitioned.html

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Horde | Nebulex.Adapters.Horde | [nebulex_adapters_horde][nbx_horde]
 [nil]: http://hexdocs.pm/nebulex/Nebulex.Adapters.Nil.html
 [nbx_cachex]: https://github.com/cabol/nebulex_adapters_cachex
 [nbx_redis]: https://github.com/cabol/nebulex_redis_adapter
-[nbx_horde]: https://github.com/cabol/nebulex_redis_adapter
+[nbx_horde]: https://github.com/cabol/nebulex_adapters_horde
 
 
 For example, if you want to use a built-in cache, add to your `mix.exs` file:


### PR DESCRIPTION
There are some differences between using `:pg` and [Horde](https://github.com/derekkraan/horde) to handle in-memory distributed data
This just adds the possibility to use Nebulex taking advantage of Horde process distribution mechanism

All the adapter tests are passing, it would be nice if you could review it too :)

https://github.com/eliasdarruda/nebulex_adapters_horde