### PR TITLE
Release space asynchronously when removing older generation

### DIFF
--- a/lib/nebulex/adapters/local/generation.ex
+++ b/lib/nebulex/adapters/local/generation.ex
@@ -496,7 +496,7 @@ defmodule Nebulex.Adapters.Local.Generation do
     end
 
     # Flush older generation to release space so it can be marked for deletion
-    true = backend.delete_all_objects(older)
+    spawn(fn -> true = backend.delete_all_objects(older) end)
 
     # Keep alive older generation reference into the metadata
     Metadata.put(meta_tab, :deprecated, older)


### PR DESCRIPTION
During cleanup, data is flushed from older generation in synchronous manner. It can create a significant bottleneck when cache size is large, because during this operation, the process is blocked.

At this point, the older generation has already been replaced in Metadata, so I think it's safe to just flush in background.