### PR TITLE
Fix nil check in `Nebulex.Adapters.Multilevel.get/3`

### DIFF
--- a/lib/nebulex/adapters/multilevel.ex
+++ b/lib/nebulex/adapters/multilevel.ex
@@ -313,10 +313,12 @@ defmodule Nebulex.Adapters.Multilevel do
   @impl true
   defspan get(adapter_meta, key, opts) do
     fun = fn level, {default, prev} ->
-      if value = with_dynamic_cache(level, :get, [key, opts]) do
-        {:halt, {value, [level | prev]}}
-      else
+      value = with_dynamic_cache(level, :get, [key, opts])
+
+      if is_nil(value) do
         {:cont, {default, [level | prev]}}
+      else
+        {:halt, {value, [level | prev]}}
       end
     end
 

--- a/test/nebulex/adapters/multilevel_inclusive_test.exs
+++ b/test/nebulex/adapters/multilevel_inclusive_test.exs
@@ -68,6 +68,14 @@ defmodule Nebulex.Adapters.MultilevelInclusiveTest do
       assert Multilevel.get(3, level: 2) == 3
     end
 
+    test "get boolean" do
+      :ok = Multilevel.put(1, true, level: 1)
+      :ok = Multilevel.put(2, false, level: 1)
+
+      assert Multilevel.get(1) == true
+      assert Multilevel.get(2) == false
+    end
+
     test "fetched value is replicated with TTL on previous levels" do
       assert Multilevel.put(:a, 1, ttl: 1000) == :ok
       assert Multilevel.ttl(:a) > 0


### PR DESCRIPTION
Fixes a bug in `Nebulex.Adapters.Multilevel.get/3` where values retrieved as `false` is returned as `nil`