### PR TITLE
Improve variable handing in key generators

### DIFF
--- a/lib/nebulex/caching/decorators.ex
+++ b/lib/nebulex/caching/decorators.ex
@@ -888,7 +888,7 @@ if Code.ensure_loaded?(Decorator.Define) do
 
     defp walk({var, _meta, context} = ast, acc) when is_atom(context) and is_atom(var) do
       cond do
-        matching?("_" <> _, "#{var}") ->
+        match?("_" <> _, "#{var}") ->
           acc
 
         Macro.special_form?(var, 0) ->

--- a/lib/nebulex/caching/decorators.ex
+++ b/lib/nebulex/caching/decorators.ex
@@ -886,10 +886,16 @@ if Code.ensure_loaded?(Decorator.Define) do
       walk(ast, acc)
     end
 
-    defp walk({var, [{:line, _} | _], nil} = ast, acc) do
-      case "#{var}" do
-        "_" <> _ -> acc
-        _ -> [ast | acc]
+    defp walk({var, _meta, context} = ast, acc) when is_atom(context) and is_atom(var) do
+      cond do
+        matching?("_" <> _, "#{var}") ->
+          acc
+
+        Macro.special_form?(var, 0) ->
+          acc
+
+        true ->
+          [ast | acc]
       end
     end
 


### PR DESCRIPTION
Relying on AST form broke my production today. We've upgraded Elixir to 1.16, but didn't upgrade the Nebulex (and it stayed in 2.5.2). And key_generator started accepting `{module, function, []}` instead of `{module, function, [opts]}` for this very basic decorator:
```
@decorate cacheable(cache: MyCache)
def function(opts) do
  ...
end
```

FYI: Variables in Elixir are always `{name, _meta, context}` when `name` and `context` are atoms. Pseudo-variables like `__MODULE__` are handled with `"_" <> _` check, but I've also introduced `Macro.special_form?` check, just in case.

You should never rely on metadata (it changed from release to release (like `counter` metadata for variables)) and you can't expect context to always be `nil` for every variable

You can trust me with these things, "I am sort of a scientist myself": https://github.com/hissssst/tria