### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/nebulex/adapters/partitioned.ex
+++ b/lib/nebulex/adapters/partitioned.ex
@@ -663,11 +663,11 @@ defmodule Nebulex.Adapters.Partitioned do
   def with_dynamic_cache(adapter_meta, action, args)
 
   def with_dynamic_cache(%{cache: cache, primary_name: nil}, action, args) do
-    apply(cache.__primary__(), action, args)
+    apply(cache.__primary__, action, args)
   end
 
   def with_dynamic_cache(%{cache: cache, primary_name: primary_name}, action, args) do
-    cache.__primary__.with_dynamic_cache(primary_name, fn ->
+    cache.__primary__().with_dynamic_cache(primary_name, fn ->
       apply(cache.__primary__, action, args)
     end)
   end

--- a/lib/nebulex/adapters/replicated.ex
+++ b/lib/nebulex/adapters/replicated.ex
@@ -363,7 +363,7 @@ defmodule Nebulex.Adapters.Replicated do
         name: normalize_module_name([name, Supervisor]),
         strategy: :rest_for_one,
         children: [
-          {cache.__primary__, primary_opts},
+          {cache.__primary__(), primary_opts},
           {__MODULE__.Bootstrap, Map.put(adapter_meta, :cache, cache)}
           | children
         ]
@@ -524,7 +524,7 @@ defmodule Nebulex.Adapters.Replicated do
   end
 
   def with_dynamic_cache(%{cache: cache, primary_name: primary_name}, action, args) do
-    cache.__primary__.with_dynamic_cache(primary_name, fn ->
+    cache.__primary__().with_dynamic_cache(primary_name, fn ->
       apply(cache.__primary__, action, args)
     end)
   end
@@ -773,7 +773,7 @@ defmodule Nebulex.Adapters.Replicated.Bootstrap do
   end
 
   defp maybe_run_on_nodes(%{cache: cache} = adapter_meta, nodes, fun) do
-    if cache.__primary__.__adapter__() == Nebulex.Adapters.Local do
+    if cache.__primary__().__adapter__() == Nebulex.Adapters.Local do
       nodes
       |> :rpc.multicall(Replicated, :with_dynamic_cache, [adapter_meta, fun, []])
       |> handle_multicall(adapter_meta)


### PR DESCRIPTION
With the Elixir 1.17 upgrade, we get a bunch of errors like this:
```
warning: using map.field notation (without parentheses) to invoke function Core.Cache.__primary__() is deprecated, you must add parentheses instead: remote.function()
  (nebulex 2.6.1) lib/nebulex/adapters/replicated.ex:366: Nebulex.Adapters.Replicated.init/1
  (nebulex 2.6.1) lib/nebulex/cache/supervisor.ex:69: Nebulex.Cache.Supervisor.init/1
  (stdlib 6.0) supervisor.erl:869: :supervisor.init/1
  (stdlib 6.0) gen_server.erl:2057: :gen_server.init_it/2
  (stdlib 6.0) gen_server.erl:2012: :gen_server.init_it/6
  (stdlib 6.0) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
```

I believe this should fix those.