### PR TITLE
Cache.all(nil, return: :value) did not correctly handle values that are lists.

### DIFF
--- a/lib/nebulex/adapters/partitioned.ex
+++ b/lib/nebulex/adapters/partitioned.ex
@@ -581,7 +581,7 @@ defmodule Nebulex.Adapters.Partitioned do
   defspan execute(adapter_meta, operation, query, opts) do
     reducer =
       case operation do
-        :all -> &List.flatten/1
+        :all -> &Enum.flat_map(&1, fn item -> item end)
         _ -> &Enum.sum/1
       end
 


### PR DESCRIPTION
Bugfix for issue https://github.com/cabol/nebulex/issues/228.

Instead of List.flatten, which will flatten out the lists within the values as well, use Enum.flat_map so only the first level gets flattened and not all the values as well.